### PR TITLE
Update concepts/index.md - Fix a spelling mistake

### DIFF
--- a/developers/weaviate/concepts/index.md
+++ b/developers/weaviate/concepts/index.md
@@ -29,7 +29,7 @@ If you are after a practical guide, try the [quickstart tutorial](/developers/we
 
 ### [Data structure](./data.md)
 
-How Weaviate deals with data objects, including how they are stores, represented, and linked to each other.
+How Weaviate deals with data objects, including how they are stored, represented, and linked to each other.
 
 ### [Modules](./modules.md)
 


### PR DESCRIPTION
Fixing `stores` -> `stored` in the concepts documentation


### What's being changed:

This is a small spelling correction in the concepts/index.md file which fixes `stores` to `stored`

### Type of change:

- [ ] **Documentation** updates (non-breaking change to fix/update documentation)

### How Has This Been Tested?

- [ ] **Local build** - the site works as expected when running `yarn start`
